### PR TITLE
be more careful about holding onto things forever

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -82,7 +82,6 @@ func (s *secureSession) RemotePublicKey() ci.PubKey {
 
 // Close closes the secure session
 func (s *secureSession) Close() error {
-	s.cancel()
 	s.handshakeMu.Lock()
 	defer s.handshakeMu.Unlock()
 	if s.secure == nil {

--- a/rw_test.go
+++ b/rw_test.go
@@ -82,4 +82,6 @@ func TestBasicETMStream(t *testing.T) {
 	if string(before) != string(msg) {
 		t.Fatal("got wrong message")
 	}
+
+	r.Close()
 }


### PR DESCRIPTION
We had a rather odd memory leak going on here. First, the context that was stored in the secureSession object wasnt needed after the handshake got run, but we held onto it until the session got closed anyways. Second, the cancel func for that was completely unnecessary, we get one inside runHandshake anyways.

![screenshot11-09-18 27 11](https://cloud.githubusercontent.com/assets/1243164/20162499/4d554624-a6aa-11e6-9c21-deb3af0f7611.png)
