### PR TITLE
immediately perform the handshake when setting up the secure session

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -16,11 +16,9 @@ type SessionGenerator struct {
 	PrivateKey ci.PrivKey
 }
 
-// NewSession takes an insecure io.ReadWriter, sets up a TLS-like
+// NewSession takes an insecure io.ReadWriter, performs a TLS-like
 // handshake with the other side, and returns a secure session.
-// The handshake isn't run until the connection is read or written to.
 // See the source for the protocol details and security implementation.
-// The provided Context is only needed for the duration of this function.
 func (sg *SessionGenerator) NewSession(ctx context.Context, insecure io.ReadWriteCloser) (Session, error) {
 	return newSecureSession(ctx, sg.LocalID, sg.PrivateKey, insecure)
 }
@@ -50,9 +48,6 @@ type Session interface {
 
 // ReadWriter returns the encrypted communication channel
 func (s *secureSession) ReadWriter() msgio.ReadWriteCloser {
-	if err := s.Handshake(); err != nil {
-		return &closedRW{err}
-	}
 	return s.secure
 }
 
@@ -68,59 +63,15 @@ func (s *secureSession) LocalPrivateKey() ci.PrivKey {
 
 // RemotePeer retrieves the remote peer.
 func (s *secureSession) RemotePeer() peer.ID {
-	if err := s.Handshake(); err != nil {
-		return ""
-	}
 	return s.remotePeer
 }
 
 // RemotePublicKey retrieves the remote public key.
 func (s *secureSession) RemotePublicKey() ci.PubKey {
-	if err := s.Handshake(); err != nil {
-		return nil
-	}
 	return s.remote.permanentPubKey
 }
 
 // Close closes the secure session
 func (s *secureSession) Close() error {
-	s.handshakeMu.Lock()
-	defer s.handshakeMu.Unlock()
-	if s.secure == nil {
-		return s.insecure.Close() // hadn't secured yet.
-	}
 	return s.secure.Close()
-}
-
-// closedRW implements a stub msgio interface that's already
-// closed and errored.
-type closedRW struct {
-	err error
-}
-
-func (c *closedRW) Read(buf []byte) (int, error) {
-	return 0, c.err
-}
-
-func (c *closedRW) Write(buf []byte) (int, error) {
-	return 0, c.err
-}
-
-func (c *closedRW) NextMsgLen() (int, error) {
-	return 0, c.err
-}
-
-func (c *closedRW) ReadMsg() ([]byte, error) {
-	return nil, c.err
-}
-
-func (c *closedRW) WriteMsg(buf []byte) error {
-	return c.err
-}
-
-func (c *closedRW) Close() error {
-	return c.err
-}
-
-func (c *closedRW) ReleaseMsg(m []byte) {
 }


### PR DESCRIPTION
This PR removes the lazy handshake. The handshake is now performed immediately when creating a new secure session.