### PR TITLE
share the buffer pool.

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"io"
 
-	msgio "github.com/jbenet/go-msgio"
 	ci "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
+	msgio "github.com/libp2p/go-msgio"
 )
 
 // SessionGenerator constructs secure communication sessions for a peer.

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmRQhVisS8dmPbjBUthVkenn81pBxrx1GxE281csJhm2vL",
+      "hash": "QmWBug6eBS7AxRdCDVuSY5CnSit7cS2XnPFYJWqWDumhCG",
       "name": "go-msgio",
-      "version": "0.0.0"
+      "version": "0.0.3"
     },
     {
       "author": "whyrusleeping",

--- a/protocol.go
+++ b/protocol.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	logging "github.com/ipfs/go-log"
-	msgio "github.com/jbenet/go-msgio"
 	ci "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pb "github.com/libp2p/go-libp2p-secio/pb"
+	msgio "github.com/libp2p/go-msgio"
 	mh "github.com/multiformats/go-multihash"
 )
 

--- a/rw.go
+++ b/rw.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 
 	proto "github.com/gogo/protobuf/proto"
-	msgio "github.com/jbenet/go-msgio"
-	mpool "github.com/jbenet/go-msgio/mpool"
+	msgio "github.com/libp2p/go-msgio"
+	mpool "github.com/libp2p/go-msgio/mpool"
 )
 
 // ErrMACInvalid signals that a MAC verification failed


### PR DESCRIPTION
Before, we were copying it (dangerously, locks and stuff), into every writer. Now, we share it (like we should...).

note: I'm not even sure if we should be using buffer pools (the allocator may be faster in this case) but that's another issue.