### PR TITLE
use minio sha256 library

### DIFF
--- a/al.go
+++ b/al.go
@@ -9,11 +9,11 @@ import (
 	"crypto/cipher"
 	"crypto/hmac"
 	"crypto/sha1"
-	"crypto/sha256"
 	"crypto/sha512"
 	"hash"
 
 	ci "github.com/libp2p/go-libp2p-crypto"
+	sha256 "github.com/minio/sha256-simd"
 	bfish "golang.org/x/crypto/blowfish"
 )
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,12 @@
       "hash": "QmYeKnKpubCMRiq3PGZcTREErthbb5Q9cXsCoSkD9bjEBd",
       "name": "go-multihash",
       "version": "1.0.6"
+    },
+    {
+      "author": "minio",
+      "hash": "QmXTpwq2AkzQsPjKqFQDNY2bMdsAT53hUBETeyj8QRHTZU",
+      "name": "sha256-simd",
+      "version": "0.1.1"
     }
   ],
   "gxVersion": "0.4.0",


### PR DESCRIPTION
It's significantly faster than the built-in one on ARM, and some Intel processors (e.g., the gateways).

Related to multiformats/go-multihash#61