### PR TITLE
switch to the buffer-pool package

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,12 @@
       "hash": "QmdxUuburamoF6zF9qjeQC4WYcWGbWuRmdLacMEsW8ioD8",
       "name": "gogo-protobuf",
       "version": "0.0.0"
+    },
+    {
+      "author": "Stebalien",
+      "hash": "QmUQy76yspPa3fRyY3GzXFTg9n8JVwFru6ue3KFRt4MeTw",
+      "name": "go-buffer-pool",
+      "version": "0.1.1"
     }
   ],
   "gxVersion": "0.4.0",


### PR DESCRIPTION
The API is significantly cleaner and safer.

Prereq for https://github.com/libp2p/go-msgio/pull/9.