### PR TITLE
Add go 1.12.x to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: go
 
 go:
   - 1.11.x
+  - 1.12.x
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
 
 env:
   global:
-    - GOTFLAGS="-race"
+    - GOTFLAGS="-race -count 2"
   matrix:
     - BUILD_DEPTYPE=gx
     - BUILD_DEPTYPE=gomod


### PR DESCRIPTION
This came up trying to find a race condition in the tests. At least 1.12 seems to find the race more reliably.