### PR TITLE
fix buffer size check

### DIFF
--- a/rw.go
+++ b/rw.go
@@ -167,7 +167,7 @@ func (r *etmReader) Read(buf []byte) (int, error) {
 
 	// If the destination buffer is too short, fill an internal buffer and then
 	// drain as much of that into the output buffer as will fit.
-	if cap(buf) < fullLen {
+	if len(buf) < fullLen {
 		err := r.fill()
 		if err != nil {
 			return 0, err


### PR DESCRIPTION
Trying to trace the source of the bug in https://github.com/libp2p/go-mplex/issues/43, I run across this erroneous check.
I don't think that's the source of the bug, but it's still a bug as it can overwrite the buffer past the slice boundary designated by the caller and perform an oversize read.
It also has similar characteristics to what we observe (an oversize read) so there is a (slim) hope that it will fix the issue.