### PR TITLE
use secureSession as normal connection

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -81,6 +81,10 @@ func (s *secureSession) Write(b []byte) (n int, err error) {
 	return s.ReadWriteCloser.Write(b)
 }
 
+func (s *secureSession) Close() error {
+	return s.insecure.Close()
+}
+
 func NewSecureSession(ctx context.Context, insecure net.Conn) (*secureSession, error) {
 	privKey, _, _ := ci.GenerateKeyPair(ci.RSA, 4096)
 	s := &secureSession{}


### PR DESCRIPTION
you can use `secureSession` like this:
```go
secio "github.com/libp2p/go-libp2p-secio"

conn, err := net.Dial("tcp", host)
if err != nil {
...
}
// generate secureConn
secureConn, err := secio.NewSecureSession(context.Background(), conn)
...
// send data
n, err := secureConn.Write(data)
...
// send file
fp, err := os.Open(file)
defer fp.Close()
_, err = io.Copy(io.MultiWriter(secureConn), fp)
```