### PR TITLE
avoid holding the message writer longer than necessary

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -50,8 +50,7 @@ const nonceSize = 16
 type secureSession struct {
 	msgio.ReadWriteCloser
 
-	insecure  net.Conn
-	insecureM msgio.ReadWriter
+	insecure net.Conn
 
 	localKey   ci.PrivKey
 	localPeer  peer.ID
@@ -88,7 +87,6 @@ func newSecureSession(ctx context.Context, local peer.ID, key ci.PrivKey, insecu
 	}
 
 	s.insecure = insecure
-	s.insecureM = msgio.NewReadWriter(insecure)
 	s.remotePeer = remotePeer
 
 	handshakeCtx, cancel := context.WithTimeout(ctx, HandshakeTimeout) // remove
@@ -135,6 +133,7 @@ func (s *secureSession) runHandshake(ctx context.Context) error {
 }
 
 func (s *secureSession) runHandshakeSync() error {
+	insecureM := msgio.NewReadWriter(s.insecure)
 	// =============================================================================
 	// step 1. Propose -- propose cipher suite + send pubkeys + nonce
 
@@ -169,11 +168,11 @@ func (s *secureSession) runHandshakeSync() error {
 	}
 
 	// Send Propose packet and Receive their Propose packet
-	proposeInBytes, err := readWriteMsg(s.insecureM, proposeOutBytes)
+	proposeInBytes, err := readWriteMsg(insecureM, proposeOutBytes)
 	if err != nil {
 		return err
 	}
-	defer s.insecureM.ReleaseMsg(proposeInBytes)
+	defer insecureM.ReleaseMsg(proposeInBytes)
 
 	// Parse their propose packet
 	proposeIn := new(pb.Propose)
@@ -280,11 +279,11 @@ func (s *secureSession) runHandshakeSync() error {
 	}
 
 	// Send Exchange packet and receive their Exchange packet
-	exchangeInBytes, err := readWriteMsg(s.insecureM, exchangeOutBytes)
+	exchangeInBytes, err := readWriteMsg(insecureM, exchangeOutBytes)
 	if err != nil {
 		return err
 	}
-	defer s.insecureM.ReleaseMsg(exchangeInBytes)
+	defer insecureM.ReleaseMsg(exchangeInBytes)
 
 	// Parse their Exchange packet.
 	exchangeIn := new(pb.Exchange)


### PR DESCRIPTION
We only need it for the handshake.