### PR TITLE
fix: wait for handshake to complete before returning

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -125,9 +125,12 @@ func (s *secureSession) runHandshake(ctx context.Context) error {
 	var err error
 	select {
 	case <-ctx.Done():
+		err = ctx.Err()
+
 		// State unknown. We *have* to close this.
 		s.insecure.Close()
-		err = ctx.Err()
+		// Wait for the handshake to return.
+		<-result
 	case err = <-result:
 	}
 	return err


### PR DESCRIPTION
That makes sure we aren't still writing/reading after we relinquish control.

fixes #40

may be related to https://github.com/ipfs/go-ipfs/issues/6197?