### PR TITLE
feat: remove sha1 hmac

### DIFF
--- a/al.go
+++ b/al.go
@@ -8,7 +8,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
-	"crypto/sha1"
 	"crypto/sha512"
 	"hash"
 
@@ -72,8 +71,6 @@ func (e *encParams) makeMacAndCipher() error {
 
 func newMac(hashType string, key []byte) (HMAC, error) {
 	switch hashType {
-	case "SHA1":
-		return HMAC{hmac.New(sha1.New, key), sha1.Size}, nil
 	case "SHA512":
 		return HMAC{hmac.New(sha512.New, key), sha512.Size}, nil
 	case "SHA256":


### PR DESCRIPTION
This hasn't been enabled since 2014 but we might as well completely remove it to remove any confusion.